### PR TITLE
Fix too-sharp corner on the viewport header button.

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -157,6 +157,7 @@ def poll_viewport(context):
 def viewport_popover_draw(self, context):
     if get_addon_preferences().viewport_popover\
     and poll_viewport(context):
+        self.layout.separator_spacer()
         self.layout.popover(panel="FONTSELECTOR_PT_viewport_popover", text="", icon="FILE_FONT")
         
 class FONTSELECTOR_PT_viewport_popover(FONTSELECTOR_panel):


### PR DESCRIPTION
Never messed with add-ons before so let me know if there's a better way to do this!

On themes with round corners, the font button seems to be trying to combine/connect to the menus on the left. I looked at how other popovers avoid this, and the viewport visibility and selectability popover has a separator_spacer before its popover. Copying that line seems to do the trick!

<img width="183" alt="Screenshot 2024-11-22 at 5 20 29 PM" src="https://github.com/user-attachments/assets/3f67a6a0-2828-40af-b4eb-041bdd6dbeb8">

<img width="183" alt="Screenshot 2024-11-22 at 5 20 05 PM" src="https://github.com/user-attachments/assets/9dfcefb8-4cd0-4b4c-8b01-0b82a6a87cd1">
