### PR TITLE
Update load_fonts.py

### DIFF
--- a/load_fonts.py
+++ b/load_fonts.py
@@ -125,7 +125,7 @@ def get_font_families_from_folder(
 
             filename, ext = os.path.splitext(file)
 
-            if ext in font_formats:
+            if ext.lower() in [f.lower() for f in font_formats]::
 
                 filepath = os.path.join(root, file)
                 font = ttLib.TTFont(filepath)


### PR DESCRIPTION
For example, if the font file extension is capitalized because of the download source then it was not loaded