### PR TITLE
Invalid fonts are skipped instead of the add-in crashing

### DIFF
--- a/load_fonts.py
+++ b/load_fonts.py
@@ -128,7 +128,18 @@ def get_font_families_from_folder(
             if ext in font_formats:
 
                 filepath = os.path.join(root, file)
-                font = ttLib.TTFont(filepath)
+                # This might cause an exception due to a corrupt font file,
+                # so catch it and continue to the next file
+                if debug:
+                    print(f"FONTSELECTOR --- Checking font : {filepath}")
+                
+                font = None
+                try:
+                    font = ttLib.TTFont(filepath)
+                except Exception as e:
+                    if debug:
+                        print(f"FONTSELECTOR --- Unable to read font : {filepath} - {e}")
+                    continue
                 family = font['name'].getDebugName(1)
 
                 font_datas = {


### PR DESCRIPTION
On my system I have a number of fonts, some of which are invalid or somehow unusable. Most applications simply ignore these; this patch checks for any error when trying to load the font file and if an exception is thrown, simply ignore it and continue through the list.